### PR TITLE
chore: import repository https://github.com/jasper2250/jenkins-quickstart2.git

### DIFF
--- a/.jx/gitops/source-config.yaml
+++ b/.jx/gitops/source-config.yaml
@@ -9,6 +9,7 @@ spec:
     providerKind: github
     repositories:
     - name: jenkins-quickstart
+    - name: jenkins-quickstart2
     scheduler: in-repo
   slack:
     channel: '#jenkins-x-pipelines'


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the CI/CD configuration](https://jenkins-x.io/docs/v3/about/how-it-works/#importing--creating-quickstarts) which will create a second commit on this Pull Request before it auto merges
